### PR TITLE
Upgrade weave & K8s, fix completion

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "applicationName": "Tesk",
     "contactEmail": "gianni@ebi.ac.uk",
     "about": "Tesk On-Premises cluster",
-    "version": "0.5",
+    "version": "0.7",
     "cloudProviders": [
         {
             "cloudProvider": "OSTACK",

--- a/ostack/ansible/playbook.yml
+++ b/ostack/ansible/playbook.yml
@@ -224,7 +224,7 @@
   tasks:
     - name: copy local weave config
       copy:
-        src: weave-2.1.3-daemonset-k8s-1.7.yaml
+        src: weave-2.4.1-daemonset-k8s-1.8.yaml
         dest: /home/{{ ansible_user_id }}/weave.yaml
     - name: apply weave config
       command: kubectl apply -f /home/{{ ansible_user_id }}/weave.yaml

--- a/ostack/ansible/playbook.yml
+++ b/ostack/ansible/playbook.yml
@@ -31,7 +31,8 @@
 
 - hosts: k8s-cluster
   pre_tasks:
-    - include_vars: versions.yml
+    - name: Include version variables
+      include_vars: versions.yml
   tags:
     - install_docker
   any_errors_fatal: true

--- a/ostack/ansible/playbook.yml
+++ b/ostack/ansible/playbook.yml
@@ -196,7 +196,7 @@
     - name: Enable kubelet service
       command: systemctl enable kubelet.service
     - name: Run kubeadm init
-      command: kubeadm init --config=/root/kubeadm.conf
+      command: kubeadm init --config=/root/kubeadm.conf --ignore-preflight-errors=cri
       register: cat
     - debug: var=cat.stdout_lines
 
@@ -246,7 +246,7 @@
     - name: Reload kubelet demo
       command: systemctl daemon-reload
     - name: Run kubeadm join
-      shell: "kubeadm join --discovery-token-unsafe-skip-ca-verification --token `cat /root/token` k8s-master:6443"
+      shell: "kubeadm join --discovery-token-unsafe-skip-ca-verification --token `cat /root/token` k8s-master:6443 --ignore-preflight-errors=cri"
 
 - hosts: kube-master
   name: small bits and bobs

--- a/ostack/ansible/playbook.yml
+++ b/ostack/ansible/playbook.yml
@@ -251,6 +251,11 @@
 - hosts: kube-master
   name: small bits and bobs
   tasks:
+    - name: Install bash-completion
+      package:
+        name: bash-completion
+        state: present
+      become: true
     - name: add autocomplete to bash_profile
       lineinfile:
         path: /home/centos/.bash_profile

--- a/ostack/ansible/vendor/roles/bastion-ssh-config/tasks/main.yml
+++ b/ostack/ansible/vendor/roles/bastion-ssh-config/tasks/main.yml
@@ -1,14 +1,17 @@
 ---
-- set_fact:
+- name: Set fact has_bastion
+  set_fact:
     has_bastion: "{{ 'bastion' in groups['all'] }}"
 
-- set_fact:
+- name: Set fact bastion_ip
+  set_fact:
     bastion_ip: "{{ hostvars['bastion']['ansible_ssh_host'] }}"
   when: has_bastion
 
 # As we are actually running on localhost, the ansible_ssh_user is your local user when you try to use it directly
 # To figure out the real ssh user, we delegate this task to the bastion and store the ansible_ssh_user in real_user
-- set_fact:
+- name: Set fact real_user
+  set_fact:
     real_user: "{{ ansible_ssh_user }}"
   delegate_to: bastion
   when: has_bastion

--- a/ostack/ansible/versions.yml
+++ b/ostack/ansible/versions.yml
@@ -1,6 +1,6 @@
 # this must be the name of the yum package version
 # for an overview of available versions, try 'yum search kubeadm --show-duplicates' with the kubernetes repo enabled
-k8s_version: "1.9.7-0"
+k8s_version: "1.10.9-0"
 
 # This should be a version that is available for the mongrelion.docker ansible role
 docker_version: "18.06.1.ce"

--- a/ostack/ansible/weave-2.4.1-daemonset-k8s-1.8.yaml
+++ b/ostack/ansible/weave-2.4.1-daemonset-k8s-1.8.yaml
@@ -41,6 +41,13 @@ items:
           - get
           - list
           - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes/status
+        verbs:
+        - patch
+        - update
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:
@@ -101,6 +108,8 @@ items:
         name: weave-net
       namespace: kube-system
     spec:
+      # Wait 5 seconds to let pod connect before rolling next pod
+      minReadySeconds: 5
       template:
         metadata:
           labels:
@@ -116,7 +125,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'weaveworks/weave-kube:2.1.3'
+              image: 'weaveworks/weave-kube:2.4.1'
               livenessProbe:
                 httpGet:
                   host: 127.0.0.1
@@ -151,7 +160,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'weaveworks/weave-npc:2.1.3'
+              image: 'weaveworks/weave-npc:2.4.1'
 #npc-args
               resources:
                 requests:
@@ -193,5 +202,6 @@ items:
             - name: xtables-lock
               hostPath:
                 path: /run/xtables.lock
+                type: FileOrCreate
       updateStrategy:
         type: RollingUpdate


### PR DESCRIPTION
- Fix kubectl completion installing bash-completion
- Improve ansible-lint conformance
- Set k8s version to 1.10.9-0
- Update `weave` to version `2.4.1` for k8s 1.8
- Increment app version to `0.7`